### PR TITLE
fix: prevent meeting controls from being pushed off-screen

### DIFF
--- a/packages/hms_room_kit/lib/src/meeting/meeting_grid_component.dart
+++ b/packages/hms_room_kit/lib/src/meeting/meeting_grid_component.dart
@@ -71,10 +71,10 @@ class MeetingGridComponent extends StatelessWidget {
                             MediaQuery.of(context).padding.top -
                             MediaQuery.of(context).padding.bottom -
                             (Platform.isAndroid
-                                ? 160
+                                ? 220
                                 : Platform.isIOS
-                                    ? 230
-                                    : 160)
+                                    ? 290
+                                    : 220)
                         : MediaQuery.of(context).size.height -
                             MediaQuery.of(context).padding.top -
                             MediaQuery.of(context).padding.bottom -

--- a/packages/hms_room_kit/lib/src/meeting/meeting_page.dart
+++ b/packages/hms_room_kit/lib/src/meeting/meeting_page.dart
@@ -129,10 +129,11 @@ class _MeetingPageState extends State<MeetingPage> {
                                     body: SafeArea(
                                       child: Theme(
                                         data: ThemeData(brightness: Brightness.dark, primaryColor: HMSThemeColors.primaryDefault, scaffoldBackgroundColor: HMSThemeColors.backgroundDim),
-                                        child: SingleChildScrollView(
+                                        child: LayoutBuilder(builder: (context, constraints) {
+                                          return SingleChildScrollView(
                                           child: SizedBox(
-                                          width: MediaQuery.of(context).size.width,
-                                          height: MediaQuery.of(context).size.height - MediaQuery.of(context).padding.top - MediaQuery.of(context).padding.bottom,
+                                          width: constraints.maxWidth,
+                                          height: constraints.maxHeight,
                                           child: Stack(
                                             children: [
                                               ChangeNotifierProvider.value(value: _visibilityController, child: MeetingGridComponent(visibilityController: _visibilityController)),
@@ -283,7 +284,8 @@ class _MeetingPageState extends State<MeetingPage> {
                                             ],
                                           ),
                                         ),
-                                        ),
+                                        );
+                                        }),
                                       ),
                                     ),
                                   );


### PR DESCRIPTION
Reduce the video grid height when controls are visible and size the meeting content to the actual available viewport height via LayoutBuilder, so the bottom navigation bar stays within view without scrolling.

# Description

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

---

## Additional context

<!-- Add any other context or additional information about the pull request.-->

*

### Pre-launch Checklist

- [ ] The [Documentation] is updated accordingly, or this PR doesn't require it.
- [ ] The [ExampleAppChangelog] is updated with related tickets, or this PR doesn't require it.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I added new tests to check the change I am making, or this PR is test-exempt.
- [ ] All existing and new tests are passing.

<!-- Links -->
[Documentation]: https://www.100ms.live/docs
[ExampleAppChangelog]: https://github.com/100mslive/100ms-flutter/blob/main/packages/hmssdk_flutter/example/ExampleAppChangelog.txt
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
